### PR TITLE
[shell-hbase] Allow user to pass HBASE_SHELL_OPTS

### DIFF
--- a/lib/cmux/commands/shell_hbase.rb
+++ b/lib/cmux/commands/shell_hbase.rb
@@ -70,7 +70,7 @@ module CMUX
         principal = get_principal(list, cm, cl)
         cmd += %( kinit #{principal} &&) if principal
         cmd += %( HADOOP_USER_NAME=#{@opt[:user]}) if @opt[:user]
-        cmd +  %( hbase shell\")
+        cmd +  %( HBASE_SHELL_OPTS='#{ENV['HBASE_SHELL_OPTS']}' hbase shell\")
       end
 
       # Retrieve keberos principal for this HBase cluster


### PR DESCRIPTION
This allows users to pass HBASE_SHELL_OPTS environment variable to the hbase shell process on the remote host. Note that I conveniently assumed that the variable doesn't hold any single or double quotes that can break the whole command 🤷‍♂️ 

See: https://github.com/apache/hbase/blob/rel/1.2.0/bin/hbase#L54-L55

```sh
HBASE_SHELL_OPTS=-Xmx2g cmux shell-hbase
```