### PR TITLE
Added '--serial-interval' option for manage_cloudera_scm_agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ lib/hbase-region-inspector/
 lib/hbase-tools/
 ext/
 !ext/example.rb
+.idea

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ Reload your shell configuration file and you should be able to see [the list of 
   Options:
       -s, --sync                       Run with synccm
       -h, --help                       Show this message
+      -i, --serial-interval N          Run with interval(sec) in serially. (default: Run in parallel)
   ```
 
 ### `manage-rackid`, `rackid`

--- a/lib/cmux/utils/opt_parser.rb
+++ b/lib/cmux/utils/opt_parser.rb
@@ -116,6 +116,20 @@ module CMUX
           end
         end
 
+        # The '--serial-interval' option
+        def serial_interval_option
+          @opts[:serial_interval] = -1
+          @parser.new do |opt|
+            opt_short = '-i'
+            opt_long  = '--serial-interval N'
+            opt_text  =
+              'Run with interval(sec) in serially. (default: Run in parallel)'
+            opt.on_tail(opt_short, opt_long, Integer, opt_text) do |e|
+              @opts[:serial_interval] = e
+            end
+          end
+        end
+
         # The '--file' option
         def file_option
           @parser.new do |opt|


### PR DESCRIPTION
Added scmagent's option(--serial-interval N)

운영 중인 클러스터에 scmagent hard_restart를 여러개의 노드에 사용하는 경우, 
해당 노드들의 서비스에 부하가 되지 않도록 한 번에 한 노드씩  간격(초)을 두고 명령을 수행하도록 함.